### PR TITLE
[Feat/service/#46] 로그인 인증 및 잡일

### DIFF
--- a/apps/service/src/apis/authMiddleware.ts
+++ b/apps/service/src/apis/authMiddleware.ts
@@ -1,0 +1,68 @@
+'use client';
+import { Middleware } from 'openapi-fetch';
+
+import { getAccessToken, setAccessToken } from '@/contexts/AuthContext';
+
+const UNPROTECTED_ROUTES = ['/api/v1/auth/admin/login'];
+
+const reissueToken = async () => {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/auth/reissue`, {
+      method: 'GET',
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error('Token reissue failed');
+
+    const data = await response.json();
+    const accessToken = data.data.accessToken;
+    setAccessToken(accessToken);
+    return accessToken;
+  } catch (error) {
+    console.error('Reissue failed:', error);
+    setAccessToken(null);
+    window.location.href = '/login';
+    return null;
+  }
+};
+
+const authMiddleware: Middleware = {
+  async onRequest({ schemaPath, request }: { schemaPath: string; request: Request }) {
+    if (UNPROTECTED_ROUTES.some((pathname) => schemaPath.startsWith(pathname))) {
+      return undefined;
+    }
+
+    let accessToken = getAccessToken();
+
+    if (!accessToken) {
+      accessToken = await reissueToken();
+
+      if (!accessToken) {
+        console.error('Access token reissue failed. Logging out...');
+        return request;
+      }
+    }
+
+    request.headers.set('Authorization', `Bearer ${accessToken}`);
+    return request;
+  },
+
+  async onResponse({ request, response }) {
+    if (response.status === 401) {
+      console.warn('Access token expired. Attempting reissue...');
+
+      const newAccessToken = await reissueToken();
+
+      if (!newAccessToken) {
+        console.error('Reissue failed. Logging out...');
+        return response;
+      }
+
+      request.headers.set('Authorization', `Bearer ${newAccessToken}`);
+      return fetch(request);
+    }
+    return response;
+  },
+};
+
+export default authMiddleware;

--- a/apps/service/src/apis/client.ts
+++ b/apps/service/src/apis/client.ts
@@ -4,9 +4,6 @@ import createClient from 'openapi-react-query';
 
 export const client = createFetchClient<paths>({
   baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
-  headers: {
-    Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
-  },
 });
 
 export const TanstackQueryClient = createClient(client);

--- a/apps/service/src/apis/controller/auth/index.ts
+++ b/apps/service/src/apis/controller/auth/index.ts
@@ -1,0 +1,3 @@
+import postLogin from './postLogin';
+
+export { postLogin };

--- a/apps/service/src/apis/controller/auth/postLogin.ts
+++ b/apps/service/src/apis/controller/auth/postLogin.ts
@@ -6,6 +6,7 @@ const postLogin = async (email: string, password: string) => {
       email,
       password,
     },
+    credentials: 'include',
   });
 };
 

--- a/apps/service/src/apis/controller/auth/postLogin.ts
+++ b/apps/service/src/apis/controller/auth/postLogin.ts
@@ -1,7 +1,7 @@
-import { fetchClient } from '@apis';
+import { client } from '@apis';
 
 const postLogin = async (email: string, password: string) => {
-  return await fetchClient.POST('/api/v1/auth/admin/login', {
+  return await client.POST('/api/v1/auth/admin/login', {
     body: {
       email,
       password,

--- a/apps/service/src/apis/controller/auth/postLogin.ts
+++ b/apps/service/src/apis/controller/auth/postLogin.ts
@@ -1,0 +1,12 @@
+import { fetchClient } from '@apis';
+
+const postLogin = async (email: string, password: string) => {
+  return await fetchClient.POST('/api/v1/auth/admin/login', {
+    body: {
+      email,
+      password,
+    },
+  });
+};
+
+export default postLogin;

--- a/apps/service/src/apis/controller/commentary/getCommentary.ts
+++ b/apps/service/src/apis/controller/commentary/getCommentary.ts
@@ -6,14 +6,22 @@ type GetCommentaryProps = {
 };
 
 const getCommentary = ({ publishId, problemId }: GetCommentaryProps) => {
-  return TanstackQueryClient.useQuery('get', '/api/v1/client/commentary', {
-    params: {
-      query: {
-        publishId: Number(publishId),
-        problemId: Number(problemId),
+  return TanstackQueryClient.useQuery(
+    'get',
+    '/api/v1/client/commentary',
+    {
+      params: {
+        query: {
+          publishId: Number(publishId),
+          problemId: Number(problemId),
+        },
       },
     },
-  });
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    }
+  );
 };
 
 export default getCommentary;

--- a/apps/service/src/apis/controller/home/getHomeFeed.ts
+++ b/apps/service/src/apis/controller/home/getHomeFeed.ts
@@ -1,8 +1,7 @@
-import { client } from '@/apis/client';
+import { TanstackQueryClient } from '@apis';
 
-const getHomeFeed = async () => {
-  const { data } = await client.GET('/api/v1/client/home-feed');
-  return data?.data;
+const getHomeFeed = () => {
+  return TanstackQueryClient.useQuery('get', '/api/v1/client/home-feed');
 };
 
 export default getHomeFeed;

--- a/apps/service/src/apis/controller/home/getHomeFeed.ts
+++ b/apps/service/src/apis/controller/home/getHomeFeed.ts
@@ -1,7 +1,15 @@
 import { TanstackQueryClient } from '@apis';
 
 const getHomeFeed = () => {
-  return TanstackQueryClient.useQuery('get', '/api/v1/client/home-feed');
+  return TanstackQueryClient.useQuery(
+    'get',
+    '/api/v1/client/home-feed',
+    {},
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    }
+  );
 };
 
 export default getHomeFeed;

--- a/apps/service/src/apis/controller/problem/getChildData.ts
+++ b/apps/service/src/apis/controller/problem/getChildData.ts
@@ -11,6 +11,10 @@ const getChildData = (publishId: string, problemId: string) => {
           problemId: Number(problemId),
         },
       },
+    },
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
     }
   );
 };

--- a/apps/service/src/apis/controller/problem/getChildProblemById.ts
+++ b/apps/service/src/apis/controller/problem/getChildProblemById.ts
@@ -12,6 +12,10 @@ const getChildProblemById = (publishId: string, problemId: string, childProblemI
           childProblemId: Number(childProblemId),
         },
       },
+    },
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
     }
   );
 };

--- a/apps/service/src/apis/controller/problem/getProblemAll.ts
+++ b/apps/service/src/apis/controller/problem/getProblemAll.ts
@@ -6,14 +6,22 @@ type GetProblemAllProps = {
 };
 
 const getProblemAll = ({ year, month }: GetProblemAllProps) => {
-  return TanstackQueryClient.useQuery('get', '/api/v1/client/problem/all/{year}/{month}', {
-    params: {
-      path: {
-        year,
-        month,
+  return TanstackQueryClient.useQuery(
+    'get',
+    '/api/v1/client/problem/all/{year}/{month}',
+    {
+      params: {
+        path: {
+          year,
+          month,
+        },
       },
     },
-  });
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    }
+  );
 };
 
 export default getProblemAll;

--- a/apps/service/src/apis/controller/problem/getProblemById.ts
+++ b/apps/service/src/apis/controller/problem/getProblemById.ts
@@ -1,14 +1,22 @@
 import { TanstackQueryClient } from '@apis';
 
 const getProblemById = (publishId: string, problemId: string) => {
-  return TanstackQueryClient.useQuery('get', '/api/v1/client/problem/{publishId}/{problemId}', {
-    params: {
-      path: {
-        publishId: Number(publishId),
-        problemId: Number(problemId),
+  return TanstackQueryClient.useQuery(
+    'get',
+    '/api/v1/client/problem/{publishId}/{problemId}',
+    {
+      params: {
+        path: {
+          publishId: Number(publishId),
+          problemId: Number(problemId),
+        },
       },
     },
-  });
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    }
+  );
 };
 
 export default getProblemById;

--- a/apps/service/src/apis/controller/problem/getProblemThumbnail.ts
+++ b/apps/service/src/apis/controller/problem/getProblemThumbnail.ts
@@ -11,6 +11,10 @@ const getProblemThumbnail = (publishId: string, problemId: string) => {
           problemId: Number(problemId),
         },
       },
+    },
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
     }
   );
 };

--- a/apps/service/src/apis/controller/problem/getProblemThumbnail.ts
+++ b/apps/service/src/apis/controller/problem/getProblemThumbnail.ts
@@ -1,15 +1,18 @@
-import { client } from '@apis';
+import { TanstackQueryClient } from '@apis';
 
-const getProblemThumbnail = async (publishId: string, problemId: string) => {
-  const { data } = await client.GET('/api/v1/client/problem/thumbnail/{publishId}/{problemId}', {
-    params: {
-      path: {
-        publishId: Number(publishId),
-        problemId: Number(problemId),
+const getProblemThumbnail = (publishId: string, problemId: string) => {
+  return TanstackQueryClient.useQuery(
+    'get',
+    '/api/v1/client/problem/thumbnail/{publishId}/{problemId}',
+    {
+      params: {
+        path: {
+          publishId: Number(publishId),
+          problemId: Number(problemId),
+        },
       },
-    },
-  });
-  return data?.data ?? {};
+    }
+  );
 };
 
 export default getProblemThumbnail;

--- a/apps/service/src/apis/controller/problem/getProblemsByPublishId.ts
+++ b/apps/service/src/apis/controller/problem/getProblemsByPublishId.ts
@@ -1,14 +1,13 @@
-import { client } from '@apis';
+import { TanstackQueryClient } from '@apis';
 
-const getProblemsByPublishId = async (publishId: string) => {
-  const { data } = await client.GET('/api/v1/client/problem/{publishId}', {
+const getProblemsByPublishId = (publishId: string) => {
+  return TanstackQueryClient.useQuery('get', '/api/v1/client/problem/{publishId}', {
     params: {
       path: {
         publishId: Number(publishId),
       },
     },
   });
-  return data?.data ?? {};
 };
 
 export default getProblemsByPublishId;

--- a/apps/service/src/apis/controller/problem/getProblemsByPublishId.ts
+++ b/apps/service/src/apis/controller/problem/getProblemsByPublishId.ts
@@ -1,13 +1,21 @@
 import { TanstackQueryClient } from '@apis';
 
 const getProblemsByPublishId = (publishId: string) => {
-  return TanstackQueryClient.useQuery('get', '/api/v1/client/problem/{publishId}', {
-    params: {
-      path: {
-        publishId: Number(publishId),
+  return TanstackQueryClient.useQuery(
+    'get',
+    '/api/v1/client/problem/{publishId}',
+    {
+      params: {
+        path: {
+          publishId: Number(publishId),
+        },
       },
     },
-  });
+    {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    }
+  );
 };
 
 export default getProblemsByPublishId;

--- a/apps/service/src/apis/index.ts
+++ b/apps/service/src/apis/index.ts
@@ -3,6 +3,7 @@ import { client, TanstackQueryClient } from './client';
 export { client, TanstackQueryClient };
 
 // controllers
+export * from './controller/auth';
 export * from './controller/home';
 export * from './controller/problem';
 export * from './controller/commentary';

--- a/apps/service/src/app/(home)/page.tsx
+++ b/apps/service/src/app/(home)/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import Link from 'next/link';
 import { Button } from '@components';
 import { IcSearch } from '@svg';
@@ -13,8 +14,9 @@ import {
   WeekProgress,
 } from '@/components/home';
 
-const Page = async () => {
-  const homeFeedData = await getHomeFeed();
+const Page = () => {
+  const { data } = getHomeFeed();
+  const homeFeedData = data?.data;
 
   const dailyProgresses = homeFeedData?.dailyProgresses;
   const problemSets = homeFeedData?.problemSets;

--- a/apps/service/src/app/login/page.tsx
+++ b/apps/service/src/app/login/page.tsx
@@ -1,8 +1,35 @@
+'use client';
+import { postLogin } from '@apis';
+import { Button, Input } from '@components';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
 import { LogoLogin } from '@/assets/svg/logo';
-import { AppleButton } from '@/components/login';
-import { KakaoButton } from '@/components/login';
+import { setAccessToken } from '@/contexts/AuthContext';
+
+interface LoginType {
+  email: string;
+  password: string;
+}
 
 const Page = () => {
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginType>();
+
+  const onSubmitLogin: SubmitHandler<LoginType> = async (formData) => {
+    const { data } = await postLogin(formData.email, formData.password);
+
+    const { accessToken } = data?.data || {};
+    if (accessToken) {
+      setAccessToken(accessToken);
+      router.push('/');
+    }
+  };
+
   return (
     <div className='mx-auto flex h-[100dvh] w-[33.5rem] flex-col pb-[2rem]'>
       <div className='flex flex-col items-center py-[9.6rem]'>
@@ -14,11 +41,41 @@ const Page = () => {
         <LogoLogin width={250} height={57} className='mt-[2.4rem]' />
         <h1 className='text-main font-bold-24 mt-[1.6rem]'>포인터</h1>
       </div>
-      <div className='mt-auto flex flex-col items-center gap-[1.6rem]'>
+      {/* <div className='mt-auto flex flex-col items-center gap-[1.6rem]'>
         <p className='font-medium-12 text-lightgray500'>포인터는 태블릿의 스플릿뷰를 권장해요</p>
         <KakaoButton />
         <AppleButton />
-      </div>
+      </div> */}
+      <form
+        onSubmit={handleSubmit(onSubmitLogin)}
+        className='mt-[4.8rem] flex flex-col items-start justify-center gap-[2.4rem]'>
+        <Input
+          type='email'
+          placeholder='이메일을 입력해주세요'
+          autoComplete='username'
+          {...register('email', {
+            required: true,
+          })}
+        />
+        <Input
+          type='password'
+          placeholder='비밀번호를 입력해주세요'
+          autoComplete='current-password'
+          {...register('password', {
+            required: true,
+            pattern: {
+              value: /^[A-Za-z0-9]*$/,
+              message: '비밀번호는 영문자와 숫자만 입력 가능합니다.',
+            },
+          })}
+        />
+        {errors.password && (
+          <p className='font-medium-16 text-red mt-[1.2rem]' role='alert'>
+            {errors.password.message}
+          </p>
+        )}
+        <Button variant='blue'>로그인</Button>
+      </form>
     </div>
   );
 };

--- a/apps/service/src/app/problem/list/[publishId]/page.tsx
+++ b/apps/service/src/app/problem/list/[publishId]/page.tsx
@@ -1,12 +1,16 @@
+'use client';
 import { Header } from '@components';
 import { getProblemsByPublishId } from '@apis';
 import dayjs from 'dayjs';
+import { useParams } from 'next/navigation';
 
 import { ProblemStatusCard } from '@/components/problem';
 
-const Page = async ({ params }: { params: Promise<{ publishId: string }> }) => {
-  const { publishId } = await params;
-  const { date, problems, title } = await getProblemsByPublishId(publishId);
+const Page = () => {
+  const { publishId } = useParams<{ publishId: string }>();
+
+  const { data } = getProblemsByPublishId(publishId);
+  const { date, problems, title } = data?.data ?? {};
   const publishDate = dayjs(date).format('MM월 DD일');
 
   return (

--- a/apps/service/src/app/problem/solve/[publishId]/[problemId]/child-problem/[childProblemId]/page.tsx
+++ b/apps/service/src/app/problem/solve/[publishId]/[problemId]/child-problem/[childProblemId]/page.tsx
@@ -73,28 +73,10 @@ const Page = () => {
   const isSolved = status === 'CORRECT' || status === 'RETRY_CORRECT';
   const isSubmitted = status === 'CORRECT' || status === 'RETRY_CORRECT' || status === 'INCORRECT';
 
-  const handleInvalidateQuery = () => {
-    queryClient.invalidateQueries({
-      queryKey: TanstackQueryClient.queryOptions(
-        'get',
-        '/api/v1/client/problem/{publishId}/{problemId}/{childProblemId}',
-        {
-          params: {
-            path: {
-              publishId: Number(publishId),
-              problemId: Number(problemId),
-              childProblemId: Number(childProblemId),
-            },
-          },
-        }
-      ).queryKey,
-    });
-  };
-
   const handleSubmitAnswer: SubmitHandler<{ answer: string }> = async ({ answer }) => {
     const { data } = await putChildProblemSubmit(publishId, childProblemId, answer);
     const resultData = data?.data;
-    handleInvalidateQuery();
+    queryClient.invalidateQueries();
 
     setResult(resultData);
     if (resultData) {
@@ -109,7 +91,7 @@ const Page = () => {
 
   const handleSkip = async () => {
     await putChildProblemSkip(publishId, childProblemId);
-    handleInvalidateQuery();
+    queryClient.invalidateQueries();
     onNext();
   };
 

--- a/apps/service/src/app/problem/solve/[publishId]/[problemId]/main-problem/page.tsx
+++ b/apps/service/src/app/problem/solve/[publishId]/[problemId]/main-problem/page.tsx
@@ -70,27 +70,11 @@ const Page = () => {
     : `새끼 문제 ${number}-${childProblemLength}번`;
   const nextButtonLabel = '해설 보기';
 
-  const handleInvalidateQuery = () => {
-    queryClient.invalidateQueries({
-      queryKey: TanstackQueryClient.queryOptions(
-        'get',
-        '/api/v1/client/problem/{publishId}/{problemId}',
-        {
-          params: {
-            path: {
-              publishId: Number(publishId),
-              problemId: Number(problemId),
-            },
-          },
-        }
-      ).queryKey,
-    });
-  };
-
   const handleSubmitAnswer: SubmitHandler<{ answer: string }> = async ({ answer }) => {
     const { data } = await putProblemSubmit(publishId, problemId, answer);
     const resultData = data?.data;
-    handleInvalidateQuery();
+    queryClient.invalidateQueries();
+
     setResult(resultData);
     if (resultData) {
       openModal();

--- a/apps/service/src/app/problem/solve/[publishId]/[problemId]/page.tsx
+++ b/apps/service/src/app/problem/solve/[publishId]/[problemId]/page.tsx
@@ -1,15 +1,15 @@
+'use client';
 import { getProblemThumbnail } from '@apis';
 import { ProgressHeader, TimeTag } from '@components';
+import { useParams } from 'next/navigation';
 
 import SolveButtonsClient from './SolveButtonsClient';
 
-const Page = async ({ params }: { params: Promise<{ publishId: string; problemId: string }> }) => {
-  const { publishId, problemId } = await params;
+const Page = () => {
+  const { publishId, problemId } = useParams<{ publishId: string; problemId: string }>();
 
-  const { number, imageUrl, recommendedMinute, recommendedSecond } = await getProblemThumbnail(
-    publishId,
-    problemId
-  );
+  const { data } = getProblemThumbnail(publishId, problemId);
+  const { number, imageUrl, recommendedMinute, recommendedSecond } = data?.data ?? {};
 
   return (
     <>

--- a/apps/service/src/app/providers.tsx
+++ b/apps/service/src/app/providers.tsx
@@ -1,17 +1,24 @@
 'use client';
+import { client } from '@apis';
+import { AuthProvider } from '@contexts';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type * as React from 'react';
 
+import authMiddleware from '@/apis/authMiddleware';
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = new QueryClient();
+  client.use(authMiddleware);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <div style={{ fontSize: '16px' }}>
-        <ReactQueryDevtools />
-      </div>
-    </QueryClientProvider>
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <div style={{ fontSize: '16px' }}>
+          <ReactQueryDevtools />
+        </div>
+      </QueryClientProvider>
+    </AuthProvider>
   );
 }

--- a/apps/service/src/components/home/ProblemSwiper/ProblemSwiper.tsx
+++ b/apps/service/src/components/home/ProblemSwiper/ProblemSwiper.tsx
@@ -45,10 +45,16 @@ const ProblemSwiper = ({ problemSets }: ProblemSwiperProps) => {
   const initialSlide = problemSets.findIndex(
     (problem) => problem.date === dayjs().format('YYYY-MM-DD')
   );
+  console.log(initialSlide);
+
+  if (initialSlide === -1) {
+    return null;
+  }
+
   return (
     <Swiper
       slidesPerView={'auto'}
-      initialSlide={initialSlide ?? 0}
+      initialSlide={initialSlide}
       spaceBetween={12}
       centeredSlides={true}
       pagination={{

--- a/apps/service/src/components/home/ProblemSwiper/ProblemSwiper.tsx
+++ b/apps/service/src/components/home/ProblemSwiper/ProblemSwiper.tsx
@@ -45,7 +45,6 @@ const ProblemSwiper = ({ problemSets }: ProblemSwiperProps) => {
   const initialSlide = problemSets.findIndex(
     (problem) => problem.date === dayjs().format('YYYY-MM-DD')
   );
-  console.log(initialSlide);
 
   if (initialSlide === -1) {
     return null;

--- a/apps/service/src/components/problem/DayProblemCard.tsx
+++ b/apps/service/src/components/problem/DayProblemCard.tsx
@@ -11,9 +11,11 @@ const answerStatusLabel = (status: string) => {
   switch (status) {
     case 'CORRECT':
     case 'RETRY_CORRECT':
-      return '완료';
     case 'INCORRECT':
+      return '완료';
+    case 'IN_PROGRESS':
       return '진행중';
+    case 'NOT_STARTED':
     default:
       return '미완료';
   }
@@ -22,9 +24,11 @@ const answerStatusColor = (status: string) => {
   switch (status) {
     case 'CORRECT':
     case 'RETRY_CORRECT':
-      return 'green';
     case 'INCORRECT':
+      return 'green';
+    case 'IN_PROGRESS':
       return 'red';
+    case 'NOT_STARTED':
     default:
       return 'gray';
   }

--- a/apps/service/src/contexts/AuthContext.tsx
+++ b/apps/service/src/contexts/AuthContext.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { createContext, useState, ReactNode } from 'react';
+
+export interface AuthContextType {
+  accessToken: string | null;
+  setAccessToken: (token: string | null) => void;
+  name: string;
+  setName: (name: string) => void;
+}
+
+const tokenStore = {
+  accessToken: null as string | null,
+  setAccessToken: (_: string | null) => {},
+};
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [accessToken, setAccessTokenState] = useState<string | null>(null);
+  const [name, setNameState] = useState<string>('');
+
+  tokenStore.accessToken = accessToken;
+  tokenStore.setAccessToken = setAccessTokenState;
+
+  const contextValue = {
+    accessToken,
+    setAccessToken: setAccessTokenState,
+    name,
+    setName: setNameState,
+  };
+
+  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+};
+
+export const getAccessToken = () => tokenStore.accessToken;
+export const setAccessToken = (token: string | null) => tokenStore.setAccessToken(token);

--- a/apps/service/src/contexts/index.ts
+++ b/apps/service/src/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from './ReportContext';
 export * from './ProblemContext';
+export { AuthContext, AuthProvider } from './AuthContext';

--- a/apps/service/src/hooks/auth/index.ts
+++ b/apps/service/src/hooks/auth/index.ts
@@ -1,0 +1,3 @@
+import useAuth from './useAuth';
+
+export { useAuth };

--- a/apps/service/src/hooks/auth/useAuth.ts
+++ b/apps/service/src/hooks/auth/useAuth.ts
@@ -1,0 +1,13 @@
+'use client';
+import { useContext } from 'react';
+import { AuthContext } from '@contexts';
+
+const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export default useAuth;


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- Feature -> main: "[Feat/Service/#1] 로그인 기능 추가" -->
<!-- main -> pre-production: "[Deploy] v1.0.0 - 2025-01-05 QA" -->
<!-- pre-production -> production: "[Release] v1.0.0 - 2025-01-05 Production" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #46 

---

## Checklist

- [x] 🎋 base 브랜치를 제대로 설정했나요? <!-- main 또는 pre-production -->
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (pnpm build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요?
- [x] 🏷️ 라벨은 등록했나요?

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 로그인 페이지 추가
    - 추후 소셜 로그인으로 바꿀 예정
2. 인증 미들웨어 & 토큰 재발급 로직 추가
3. 캘린더 뷰에 상태 잘못나오는거 수정
4. tanstack query에서 gcTime, staleTime 설정해줌
    - 내 문제 풀이 관련 정보(정답, 진행도 등등) 말고는 다 캐싱돼도 됨
    - 그래서 싹다 Infinity로 하고, 문제 채점 API 쏘면 싹 invalidate시키는 방식으로 설정함

---

## 💡 New Insights & Learnings

- 미들웨어 설정이 정말 힘들었음...............
- openapi-fetch 에서 제공하는 Middleware를 사용하는데, 이게 서버컴포넌트에 적용이 안됐음..
- 정확하게는 서버컴포넌트 request를 가로채서 여기에 인증 헤더를 추가해줘야하는데 이게 안됨...
- 어쩔수 없이 서버 컴포넌트로 get하는 함수들을 클라이언트 컴포넌트로 바꾸고, useQuery로 get해왔음(다행히 home 피드 조회 1개였음)
