### PR TITLE
[Fix/admin/#52] Tanstack Query Invalidate 문제 수정

### DIFF
--- a/apps/admin/src/hooks/index.ts
+++ b/apps/admin/src/hooks/index.ts
@@ -4,5 +4,14 @@ import useAnswerInput from './useAnswerInput';
 import useNavigation from './useNavigation';
 import useAuth from './useAuth';
 import useProblemEssentialInput from './useProblemEssentialInput';
+import useInvalidate from './useInvalidate';
 
-export { useModal, useSelectTag, useAnswerInput, useNavigation, useAuth, useProblemEssentialInput };
+export {
+  useModal,
+  useSelectTag,
+  useAnswerInput,
+  useNavigation,
+  useAuth,
+  useProblemEssentialInput,
+  useInvalidate,
+};

--- a/apps/admin/src/hooks/useInvalidate.ts
+++ b/apps/admin/src/hooks/useInvalidate.ts
@@ -9,19 +9,23 @@ const useInvalidate = () => {
   };
 
   const invalidateProblemSet = (problemSetId: number) => {
-    queryClient.invalidateQueries({
-      queryKey: [
-        $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
+    return Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
           params: {
             path: {
               problemSetId,
             },
           },
         }).queryKey,
-        $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
-        $api.queryOptions('get', '/api/v1/problemSet/confirm/search').queryKey,
-      ],
-    });
+      }),
+      queryClient.invalidateQueries({
+        queryKey: $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
+      }),
+      queryClient.invalidateQueries({
+        queryKey: $api.queryOptions('get', '/api/v1/problemSet/confirm/search').queryKey,
+      }),
+    ]);
   };
 
   const invalidatePublish = (year: number, month: number) => {

--- a/apps/admin/src/hooks/useInvalidate.ts
+++ b/apps/admin/src/hooks/useInvalidate.ts
@@ -1,0 +1,43 @@
+import { $api } from '@apis';
+import { useQueryClient } from '@tanstack/react-query';
+
+const useInvalidate = () => {
+  const queryClient = useQueryClient();
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries();
+  };
+
+  const invalidateProblemSet = (problemSetId: number) => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
+          params: {
+            path: {
+              problemSetId,
+            },
+          },
+        }).queryKey,
+        $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
+        $api.queryOptions('get', '/api/v1/problemSet/confirm/search').queryKey,
+      ],
+    });
+  };
+
+  const invalidatePublish = (year: number, month: number) => {
+    queryClient.invalidateQueries({
+      queryKey: $api.queryOptions('get', '/api/v1/publish/{year}/{month}', {
+        params: {
+          path: {
+            year,
+            month,
+          },
+        },
+      }).queryKey,
+    });
+  };
+
+  return { invalidateAll, invalidateProblemSet, invalidatePublish };
+};
+
+export default useInvalidate;

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -8,7 +8,14 @@ import { routeTree } from './routeTree.gen';
 
 import './styles/globals.css';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    },
+  },
+});
 
 // Set up a Router instance
 const router = createRouter({

--- a/apps/admin/src/routes/_GNBLayout/problem-set/$problemSetId/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/problem-set/$problemSetId/index.tsx
@@ -1,10 +1,4 @@
-import {
-  $api,
-  deleteProblemSet,
-  getProblemSetById,
-  putConfirmProblemSet,
-  putProblemSet,
-} from '@apis';
+import { deleteProblemSet, getProblemSetById, putConfirmProblemSet, putProblemSet } from '@apis';
 import {
   Button,
   ComponentWithLabel,
@@ -20,9 +14,8 @@ import {
   Tag,
   TwoButtonModalTemplate,
 } from '@components';
-import { useModal } from '@hooks';
+import { useInvalidate, useModal } from '@hooks';
 import { components } from '@schema';
-import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -50,7 +43,7 @@ type ErrorResponse = components['schemas']['ErrorResponse'];
 function RouteComponent() {
   const { problemSetId } = Route.useParams();
   const { navigate } = useRouter();
-  const queryClient = useQueryClient();
+  const { invalidateProblemSet } = useInvalidate();
 
   const [problemSummaries, setProblemSummaries] = useState<ProblemSummaryResponse[]>([]);
   const [currentProblemIndex, setCurrentProblemIndex] = useState<number>(0);
@@ -116,15 +109,7 @@ function RouteComponent() {
       },
       {
         onSuccess: (data) => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
-              params: {
-                path: {
-                  problemSetId: Number(problemSetId),
-                },
-              },
-            }).queryKey,
-          });
+          invalidateProblemSet(Number(problemSetId));
           if (data.data === 'CONFIRMED') {
             toast.success('컨펌이 완료되었습니다');
           } else {
@@ -150,9 +135,7 @@ function RouteComponent() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
-          });
+          invalidateProblemSet(Number(problemSetId));
           navigate({ to: '/problem-set' });
         },
       }
@@ -284,15 +267,7 @@ function RouteComponent() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
-              params: {
-                path: {
-                  problemSetId: Number(problemSetId),
-                },
-              },
-            }).queryKey,
-          });
+          invalidateProblemSet(Number(problemSetId));
           toast.success('저장이 완료되었습니다');
           setIsSaved(true);
         },

--- a/apps/admin/src/routes/_GNBLayout/problem-set/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/problem-set/index.tsx
@@ -1,4 +1,4 @@
-import { $api, deleteProblemSet, getSearchProblemSet, postProblemSet } from '@apis';
+import { deleteProblemSet, getSearchProblemSet, postProblemSet } from '@apis';
 import {
   Button,
   FloatingButton,

--- a/apps/admin/src/routes/_GNBLayout/problem-set/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/problem-set/index.tsx
@@ -10,8 +10,7 @@ import {
   SectionCard,
   TwoButtonModalTemplate,
 } from '@components';
-import { useModal } from '@hooks';
-import { useQueryClient } from '@tanstack/react-query';
+import { useInvalidate, useModal } from '@hooks';
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
 import { getSearchProblemSetParamsType } from '@types';
 import { useRef, useState } from 'react';
@@ -22,7 +21,7 @@ export const Route = createFileRoute('/_GNBLayout/problem-set/')({
 });
 
 function RouteComponent() {
-  const queryClient = useQueryClient();
+  const { invalidateProblemSet } = useInvalidate();
   const { navigate } = useRouter();
 
   const [searchQuery, setSearchQuery] = useState<getSearchProblemSetParamsType>({});
@@ -70,9 +69,7 @@ function RouteComponent() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
-          });
+          invalidateProblemSet(deleteProblemSetId.current ?? 0);
           closeDeleteModal();
         },
       }

--- a/apps/admin/src/routes/_GNBLayout/problem/$problemId/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/problem/$problemId/index.tsx
@@ -21,7 +21,6 @@ import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { Controller, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { produce } from 'immer';
 import {
-  $api,
   deleteChildProblem,
   deleteProblems,
   getConceptTags,
@@ -31,8 +30,7 @@ import {
 } from '@apis';
 import { useEffect, useState } from 'react';
 import { transformToProblemUpdateRequest } from '@utils';
-import { useQueryClient } from '@tanstack/react-query';
-import { useModal } from '@hooks';
+import { useInvalidate, useModal } from '@hooks';
 import { Slide, ToastContainer, toast } from 'react-toastify';
 
 export const Route = createFileRoute('/_GNBLayout/problem/$problemId/')({
@@ -44,7 +42,7 @@ type ProblemUpdateRequest = components['schemas']['ProblemUpdateRequest'];
 
 function RouteComponent() {
   // hooks
-  const queryClient = useQueryClient();
+  const { invalidateAll } = useInvalidate();
   const { navigate } = useRouter();
   const { problemId } = Route.useParams();
   const { isOpen: isTagModalOpen, openModal: openTagModal, closeModal: closeTagModal } = useModal();
@@ -161,13 +159,7 @@ function RouteComponent() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', `/api/v1/problems/{id}`, {
-              params: {
-                path: { id: Number(problemId) },
-              },
-            }).queryKey,
-          });
+          invalidateAll();
           toast.success('저장이 완료되었습니다');
         },
       }
@@ -185,9 +177,7 @@ function RouteComponent() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problems/search').queryKey,
-          });
+          invalidateAll();
           navigate({ to: '/problem' });
         },
       }

--- a/apps/admin/src/routes/_GNBLayout/problem/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/problem/index.tsx
@@ -1,4 +1,4 @@
-import { $api, deleteProblems, getConceptTags, getProblemsSearch } from '@apis';
+import { deleteProblems, getConceptTags, getProblemsSearch } from '@apis';
 import {
   Button,
   FloatingButton,
@@ -11,9 +11,8 @@ import {
   TagSelectModal,
   TwoButtonModalTemplate,
 } from '@components';
-import { useModal } from '@hooks';
+import { useInvalidate, useModal } from '@hooks';
 import { IcDown } from '@svg';
-import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { getProblemsSearchParamsType } from '@types';
 import { useRef, useState } from 'react';
@@ -25,7 +24,7 @@ export const Route = createFileRoute('/_GNBLayout/problem/')({
 });
 
 function RouteComponent() {
-  const queryClient = useQueryClient();
+  const { invalidateAll } = useInvalidate();
 
   const { isOpen, openModal, closeModal } = useModal();
   const {
@@ -69,9 +68,7 @@ function RouteComponent() {
       {
         onSuccess: () => {
           closeDeleteModal();
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problems/search').queryKey,
-          });
+          invalidateAll();
         },
       }
     );

--- a/apps/admin/src/routes/_GNBLayout/problem/register/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/problem/register/index.tsx
@@ -1,9 +1,9 @@
-import { $api, postProblems } from '@apis';
+import { postProblems } from '@apis';
 import { Button, Header, ProblemEssentialInput } from '@components';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { Controller, useForm } from 'react-hook-form';
 import { components } from '@schema';
-import { useQueryClient } from '@tanstack/react-query';
+import { useInvalidate } from '@hooks';
 
 export const Route = createFileRoute('/_GNBLayout/problem/register/')({
   component: RouteComponent,
@@ -13,7 +13,7 @@ type ProblemPostRequest = components['schemas']['ProblemPostRequest'];
 
 function RouteComponent() {
   const { navigate } = useRouter();
-  const queryClient = useQueryClient();
+  const { invalidateAll } = useInvalidate();
 
   const { mutate } = postProblems();
   const {
@@ -40,9 +40,7 @@ function RouteComponent() {
       },
       {
         onSuccess: (data) => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/problems/search').queryKey,
-          });
+          invalidateAll();
           const { id } = data.data;
           navigate({ to: `/problem/${id}` });
         },

--- a/apps/admin/src/routes/_GNBLayout/publish/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/publish/index.tsx
@@ -3,9 +3,8 @@ import { IconButton, Modal, PlusButton, TwoButtonModalTemplate } from '@componen
 import { HTMLAttributes, useState } from 'react';
 import { IcDeleteSm } from '@svg';
 import { Link } from '@tanstack/react-router';
-import { $api, deletePublish, getPublish } from '@apis';
-import { useModal } from '@hooks';
-import { useQueryClient } from '@tanstack/react-query';
+import { deletePublish, getPublish } from '@apis';
+import { useInvalidate, useModal } from '@hooks';
 import dayjs from 'dayjs';
 
 import 'dayjs/locale/ko';
@@ -21,7 +20,7 @@ interface DayProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const Day = ({ fullDate, day, dayOfWeek, publishId, title, setId }: DayProps) => {
-  const queryClient = useQueryClient();
+  const { invalidatePublish } = useInvalidate();
   const {
     isOpen: isDeleteModalOpen,
     openModal: openDeleteModal,
@@ -57,16 +56,7 @@ const Day = ({ fullDate, day, dayOfWeek, publishId, title, setId }: DayProps) =>
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/publish/{year}/{month}', {
-              params: {
-                path: {
-                  year: dayjs(fullDate).year(),
-                  month: dayjs(fullDate).month() + 1,
-                },
-              },
-            }).queryKey,
-          });
+          invalidatePublish(dayjs(fullDate).year(), dayjs(fullDate).month() + 1);
           closeDeleteModal();
         },
       }

--- a/apps/admin/src/routes/_GNBLayout/publish/register/$publishDate/index.tsx
+++ b/apps/admin/src/routes/_GNBLayout/publish/register/$publishDate/index.tsx
@@ -1,4 +1,4 @@
-import { $api, getConfirmProblemSet, postPublish } from '@apis';
+import { getConfirmProblemSet, postPublish } from '@apis';
 import {
   Button,
   FloatingButton,
@@ -8,7 +8,7 @@ import {
   SearchInput,
   SectionCard,
 } from '@components';
-import { useQueryClient } from '@tanstack/react-query';
+import { useInvalidate } from '@hooks';
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
 import { getSearchProblemSetParamsType } from '@types';
 import { useState } from 'react';
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/_GNBLayout/publish/register/$publishDate/
 });
 
 function RouteComponent() {
-  const queryClient = useQueryClient();
+  const { invalidatePublish } = useInvalidate();
   const { navigate } = useRouter();
   const { publishDate } = Route.useParams();
   const dateArr = publishDate.split('-');
@@ -62,16 +62,7 @@ function RouteComponent() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: $api.queryOptions('get', '/api/v1/publish/{year}/{month}', {
-              params: {
-                path: {
-                  year: Number(year),
-                  month: Number(month),
-                },
-              },
-            }).queryKey,
-          });
+          invalidatePublish(Number(year), Number(month));
           navigate({ to: '/publish' });
         },
       }

--- a/apps/service/src/app/problem/solve/[publishId]/[problemId]/child-problem/[childProblemId]/page.tsx
+++ b/apps/service/src/app/problem/solve/[publishId]/[problemId]/child-problem/[childProblemId]/page.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { getChildProblemById, TanstackQueryClient } from '@apis';
+import { getChildProblemById } from '@apis';
 import { putChildProblemSubmit, putChildProblemSkip } from '@apis';
 import {
   AnswerInput,
@@ -15,9 +15,8 @@ import {
   TwoButtonModalTemplate,
   AnswerModalTemplate,
 } from '@components';
-import { useModal } from '@hooks';
+import { useInvalidate, useModal } from '@hooks';
 import { components } from '@schema';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { useChildProblemContext } from '@/hooks/problem';
 
@@ -31,7 +30,7 @@ const Page = () => {
   }>();
   const router = useRouter();
   const { childProblemLength, mainProblemImageUrl, onPrev, onNext } = useChildProblemContext();
-  const queryClient = useQueryClient();
+  const { invalidateAll } = useInvalidate();
 
   const { isOpen, openModal, closeModal } = useModal();
   const {
@@ -76,7 +75,7 @@ const Page = () => {
   const handleSubmitAnswer: SubmitHandler<{ answer: string }> = async ({ answer }) => {
     const { data } = await putChildProblemSubmit(publishId, childProblemId, answer);
     const resultData = data?.data;
-    queryClient.invalidateQueries();
+    invalidateAll();
 
     setResult(resultData);
     if (resultData) {
@@ -91,7 +90,7 @@ const Page = () => {
 
   const handleSkip = async () => {
     await putChildProblemSkip(publishId, childProblemId);
-    queryClient.invalidateQueries();
+    invalidateAll();
     onNext();
   };
 

--- a/apps/service/src/app/problem/solve/[publishId]/[problemId]/main-problem/page.tsx
+++ b/apps/service/src/app/problem/solve/[publishId]/[problemId]/main-problem/page.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { getProblemById, putProblemSubmit, TanstackQueryClient } from '@apis';
+import { getProblemById, putProblemSubmit } from '@apis';
 import {
   AnswerInput,
   Button,
@@ -14,9 +14,8 @@ import {
   SmallButton,
   NavigationFooter,
 } from '@components';
-import { useModal } from '@hooks';
+import { useInvalidate, useModal } from '@hooks';
 import { ProblemStatus } from '@types';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { useChildProblemContext } from '@/hooks/problem';
 
@@ -38,7 +37,7 @@ const Page = () => {
   const { publishId, problemId } = useParams<{ publishId: string; problemId: string }>();
   const router = useRouter();
   const { childProblemLength } = useChildProblemContext();
-  const queryClient = useQueryClient();
+  const { invalidateAll } = useInvalidate();
 
   const { isOpen, openModal, closeModal } = useModal();
   const [result, setResult] = useState<ProblemStatus | undefined>();
@@ -73,7 +72,7 @@ const Page = () => {
   const handleSubmitAnswer: SubmitHandler<{ answer: string }> = async ({ answer }) => {
     const { data } = await putProblemSubmit(publishId, problemId, answer);
     const resultData = data?.data;
-    queryClient.invalidateQueries();
+    invalidateAll();
 
     setResult(resultData);
     if (resultData) {

--- a/apps/service/src/hooks/common/index.ts
+++ b/apps/service/src/hooks/common/index.ts
@@ -1,3 +1,4 @@
 import useModal from './useModal';
+import useInvalidate from './useInvalidate';
 
-export { useModal };
+export { useModal, useInvalidate };

--- a/apps/service/src/hooks/common/useInvalidate.ts
+++ b/apps/service/src/hooks/common/useInvalidate.ts
@@ -1,0 +1,13 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+const useInvalidate = () => {
+  const queryClient = useQueryClient();
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries();
+  };
+
+  return { invalidateAll };
+};
+
+export default useInvalidate;


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- Feature -> main: "[Feat/Service/#1] 로그인 기능 추가" -->
<!-- main -> pre-production: "[Deploy] v1.0.0 - 2025-01-05 QA" -->
<!-- pre-production -> production: "[Release] v1.0.0 - 2025-01-05 Production" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #52  

---

## Checklist

- [x] 🎋 base 브랜치를 제대로 설정했나요? <!-- main 또는 pre-production -->
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (pnpm build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요?
- [x] 🏷️ 라벨은 등록했나요?

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 문제상황

<img width="774" alt="image" src="https://github.com/user-attachments/assets/cec99d64-a771-49c1-b83e-ff2bbffd7663" />

tanstack query의 refetchOnWindowFocus 때문에 다른 창에 갔당오면 데이터를 refetch 하면서 저장하지 않는 입력값들이 초기화 돼버리는 문제가 생김

### 해결방법

1. refetchOnWindowFocus 설정과 적절한 staleTime 설정
- 가장 일반적인 방법
2. defaultOptions로 staleTime, gcTime을 Infinity로 설정하고, 적절히 Invalidate 
- 내가 선택한 방법

이렇게 한 이유는 다음과 같음.

```tsx
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      staleTime: Infinity,
      gcTime: Infinity,
    },
  },
});
```
이렇게 해서 모든 쿼리를 조건없이 캐싱 해버림

이유는, 관리자 페이지에서는 주기적으로 갱신돼야 하는 데이터가 없음. 
`문제` -> 문제가 모인 `세트` -> 세트가 날짜에 연결된 `발행` 데이터들만 있는데, 이는 관리자페이지에서 어떤 수정이 일어나지 않는한 변경되지 않음.

**그래서 모든 데이터를 Infinity로 캐싱하고, 수정이 일어날때 적절하게 invalidate시켜주는 방법을 선택했음**

> tanstack query는 **stale인 데이터가 트리거(OnWindowFocus 등)를 만족**하면 refetch가 일어남
> 즉, 이렇게 모든 데이터를 fresh하게 유지하게되면 현재 문제 상황인 데이터 refetch 문제도 해결가능함
> (fresh라서 onWindowFocus나 reconnect 등이 일어나도 refech가 안됨)

대신, 업데이트 되어야하는 모든 쿼리를 적절하게 invalidate 시켜주지 않으면 최신 데이터가 제대로 보이지 않을 수있음.

---

### 데이터 Invalidate 시키기

업데이트가 크게 `문제`, `세트`, `발행` 세군데에서 일어남.
**`문제` -> 문제가 모인 `세트` -> 세트가 날짜에 연결된 `발행`**  구조이기 때문에 사실 문제가 수정되면 모든 데이터가 바뀐다고 할 수 있음

그래서 문제의 업데이트에 대해서는 그냥 모든 쿼리를 invalidate 시켜버림
(조금 비효율적일 수는 있지만, 뭘 빠뜨리는것보다는 낫다고 판단함,,,)

세트의 업데이트에 대한 invalidate
- 해당 id 세트
- 세트 목록
- 컨펌된 세트 목록

발행 업데이트에 대한 invalidate
- 해당 연월에 대한 발행 목록

### useInvalidate 훅 생성

반복되는 invalidate 를 커스텀 훅으로 빼줬음.
필요한 query를 정확하게 Invalidate 시키기 위함도 있고,
openapi-react-query를 쓰다보니 invalidate 코드가 너무길어서 반복을 줄이기 위함도 있음

#### 모든 쿼리 invalidate
```ts
  const invalidateAll = () => {
    queryClient.invalidateQueries();
  };
```

#### 문항 세트 관련 쿼리 invalidate
```ts
  const invalidateProblemSet = (problemSetId: number) => {
    return Promise.all([
      queryClient.invalidateQueries({
        queryKey: $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
          params: {
            path: {
              problemSetId,
            },
          },
        }).queryKey,
      }),
      queryClient.invalidateQueries({
        queryKey: $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
      }),
      queryClient.invalidateQueries({
        queryKey: $api.queryOptions('get', '/api/v1/problemSet/confirm/search').queryKey,
      }),
    ]);
  };
```

#### 문항 발행 관련 쿼리 invalidate
```ts
 const invalidatePublish = (year: number, month: number) => {
    queryClient.invalidateQueries({
      queryKey: $api.queryOptions('get', '/api/v1/publish/{year}/{month}', {
        params: {
          path: {
            year,
            month,
          },
        },
      }).queryKey,
    });
  };
```
---

## 💡 New Insights & Learnings 

```ts
  const invalidateProblemSet = (problemSetId: number) => {
    queryClient.invalidateQueries({
      queryKey: [
        $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
          params: {
            path: {
              problemSetId,
            },
          },
        }).queryKey,
        $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
        $api.queryOptions('get', '/api/v1/problemSet/confirm/search').queryKey,
      ],
    });
  };
```
원래 문제 세트 invalidate할때 이런식으로 여러개의 쿼리를 invalidate시키려고 했는데, 제대로안됨

알아보니, 저렇게 여러개의 쿼리를 넣으면 or 조건으로 처리되는게 아니라, 
- [queryKey1, queryKey2, queryKey3]로 시작하는 모든 쿼리와 일치.
- queryKey1로 시작하는 쿼리와 queryKey2로 시작하는 쿼리를 모두 무효화하는 것이 아님
라고함.

그래서 각각에 대해 invalidate를 시키려면
Promise.all을 이용해서 모두를 invalidate시켜야함

따라서

```ts
  const invalidateProblemSet = (problemSetId: number) => {
    return Promise.all([
      queryClient.invalidateQueries({
        queryKey: $api.queryOptions('get', '/api/v1/problemSet/{problemSetId}', {
          params: { path: { problemSetId } },
        }).queryKey,
      }),
      queryClient.invalidateQueries({
        queryKey: $api.queryOptions('get', '/api/v1/problemSet/search').queryKey,
      }),
      queryClient.invalidateQueries({
        queryKey: $api.queryOptions('get', '/api/v1/problemSet/confirm/search').queryKey,
      }),
    ]);
  };
```

요런 코드가 됐음.

잘 동작함 👍
